### PR TITLE
Fix #12602: Buttons and scroll-bar no longer overlap

### DIFF
--- a/src/palette/qml/MuseScore/Palette/internal/AddPalettesPopup.qml
+++ b/src/palette/qml/MuseScore/Palette/internal/AddPalettesPopup.qml
@@ -89,10 +89,12 @@ StyledPopupView {
         StyledListView {
             id: palettesList
             height: Math.min(availableHeight, contentHeight)
-            width: parent.width
+            width: parent.width + margins
 
             readonly property int availableHeight:
                 root.maxHeight - header.height - createCustomPaletteButton.height - 2 * contentColumn.spacing
+
+            scrollBarThickness: 6
 
             spacing: 8
             visible: count > 0
@@ -100,7 +102,7 @@ StyledPopupView {
             delegate: Item {
                 id: morePalettesDelegate
 
-                width: parent.width
+                width: parent.width - margins
                 height: addButton.height
 
                 property bool added: false


### PR DESCRIPTION
Resolves: #12602

AddPalettesPopup's inner StyledListView ignores right margin, allowing the scroll-bar to display at the edge of the popup. The delegates inside the list do not ignore the margins, giving space for the scroll-bar.