### PR TITLE
Fix #16516: Format->Reset text overrides can now be undone

### DIFF
--- a/src/engraving/libmscore/cmd.cpp
+++ b/src/engraving/libmscore/cmd.cpp
@@ -2344,7 +2344,7 @@ void Score::cmdResetTextStyleOverrides()
             }
 
             for (Pid propertyId : propertiesToReset) {
-                element->resetProperty(propertyId);
+                element->undoResetProperty(propertyId);
             }
         }
     }

--- a/src/notation/internal/notationuiactions.cpp
+++ b/src/notation/internal/notationuiactions.cpp
@@ -1422,8 +1422,8 @@ const UiActionList NotationUiActions::m_actions = {
     UiAction("reset-beammode",
              mu::context::UiCtxNotationOpened,
              mu::context::CTX_NOTATION_OPENED,
-             TranslatableString("action", "Reset &beams"),
-             TranslatableString("action", "Reset beams to default grouping")
+             TranslatableString("action", "Reset &beam properties"),
+             TranslatableString("action", "Reset all beam properties to default")
              ),
     UiAction("reset",
              mu::context::UiCtxNotationOpened,


### PR DESCRIPTION
Resolves: #16516

Format->Reset text overrides can now be undone. Another point brought up in this issue was the naming of "Format->Reset beams", this has been renamed to "Reset beam properties" (as suggested).